### PR TITLE
Add future:false to _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,3 +5,4 @@ description: > # this means to ignore newlines until "baseurl:"
 url: "http://lapikud.ee" # the base hostname & protocol for your site, e.g. http://example.com
 instagram_username: lapikud
 github_username:  lapikud
+future: false


### PR DESCRIPTION
Github pages by default shows all posts, even those that are dated in the future.
This change should disable posts with dates in the future.