### PR TITLE
moved some senior members to graduates

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -22,7 +22,6 @@ senior:
   - Carina Ruut
   - Carmen Unt
   - Diana Christine Tarro
-  - Elis-Christina Kuuse
   - Emil Marvin Mikk
   - Gleb Engalychev
   - Gregor Kaljulaid
@@ -30,7 +29,6 @@ senior:
   - Helena Grete Lillepalu
   - Henri Helisma
   - Henrik Hansson
-  - Ingrid-Regina Vähi
   - Jan-Markus Üprus
   - Jolanta Rudus
   - Jose Daniel Morales Sööt
@@ -45,7 +43,6 @@ senior:
   - Laura Anni
   - Lembitu Valdmets
   - Liisa Heinla
-  - Madis Müil
   - Madis Rohtla
   - Marcus Pruks
   - Mart Kaasik
@@ -63,7 +60,6 @@ senior:
   - Ragnar Kaseorg
   - Reivo Türnpuu
   - Robin Väli
-  - Roosi-Ann Tõlgu
   - Sander Kornet
   - Saskia Rohtla
   - Siret Sillar
@@ -124,6 +120,7 @@ graduates:
   - Egert Aia
   - Elen Väin
   - Elina Kapanen
+  - Elis-Christina Kuuse
   - Elisa Tamm
   - Elo Pelovas
   - Enola Sander
@@ -162,6 +159,7 @@ graduates:
   - Ingel-Marie Hiiekivi
   - Ingmar Trump
   - Ingrid Vuks
+  - Ingrid-Regina Vähi
   - Innar Liiv
   - Ivo Müürsepp
   - Jaak Lember
@@ -230,6 +228,7 @@ graduates:
   - Madis Eensoo
   - Madis Fuks
   - Madis Kõosaar
+  - Madis Müil
   - Madis Puju
   - Madis Seppam
   - Madis-Siim Rull
@@ -305,6 +304,7 @@ graduates:
   - Robert Rosimannus
   - Roel Rahkema
   - Roger Kerse
+  - Roosi-Ann Tõlgu
   - Sander Aasaväli
   - Sander Roosik
   - Sander Ruul


### PR DESCRIPTION
Vanemliikmetest kolisid vilistlaste sekka: Ingrid-Regina Vähi, Elis-Christina Kuuse, Roosi-Ann Tõlgu ja Madis Müil.