### PR TITLE
Fix mentors' section not filling all available horizontal space, when…

### DIFF
--- a/_sass/mentors.scss
+++ b/_sass/mentors.scss
@@ -2,6 +2,7 @@
 
   .mentor {
     display        : flex;
+    width          : 100%;
     flex-direction : row;
     margin         : 4rem auto;
 


### PR DESCRIPTION
… description/text next to it is too short

Fixes #114